### PR TITLE
sdk-python: document append null padding

### DIFF
--- a/content/dbms/sdk-integration/python.en.md
+++ b/content/dbms/sdk-integration/python.en.md
@@ -6,7 +6,7 @@ weight: 30
 
 ## Overview
 
-This guide is updated for the 2.1 package: install name is lowercase `machbaseapi`, and the package is now implemented in pure Python (no native `.so/.dll/.dylib` dependency).
+This guide is updated for the 2.3 package: install name is lowercase `machbaseapi`, and the package is now implemented in pure Python (no native `.so/.dll/.dylib` dependency).
 
 You can continue using `import machbaseAPI` and existing `machbase` call patterns.
 
@@ -15,7 +15,9 @@ You can continue using `import machbaseAPI` and existing `machbase` call pattern
 - DB-API style: `connect()` and `cursor()` are available
 - `append*` callbacks can be observed through optional `on_ack` in append APIs.
 - `append()`, `appendByTime()`, `appendData()`, and `appendDataByTime()` can be called without explicit column type codes; Machbase metadata is used for type inference.
-- Connection-pool options are intentionally unsupported in 2.1 (`pool_name`, `pool_size`, `pool_reset_session`)
+- In 2.3, trailing columns omitted from append rows are stored as `NULL` through append null-bit metadata.
+- For TAG tables, values through the `value` column are required; later value/meta columns can be omitted and stored as `NULL`.
+- Connection-pool options are intentionally unsupported in 2.3 (`pool_name`, `pool_size`, `pool_reset_session`)
 
 The examples below target the `machbase` class, which remains the main entry point for legacy-style scripts.
 
@@ -25,7 +27,7 @@ The examples below target the `machbase` class, which remains the main entry poi
 
 - Python 3.8 or later with `pip`.
 - A reachable Machbase server and credentials (default `SYS/MANAGER` on port `5656`).
-- No native Machbase shared library installation is required in 2.1.
+- No native Machbase shared library installation is required in 2.3.
 
 ### Install from PyPI
 
@@ -48,7 +50,7 @@ PY
 
 A successful run confirms that the package can be imported and instantiated.
 
-You can also run 2.1-style DB-API samples with `connect()`.
+You can also run DB-API samples with `connect()`.
 
 ```python
 from machbaseAPI import connect
@@ -145,14 +147,14 @@ Most `machbase` methods return `1` on success and `0` on failure. After each cal
 | `machbase` | `selectClose()` | Close an open result set cursor. | `1` or `0` |
 | `machbase` | `result()` | Return the latest JSON payload. | JSON string |
 | `machbase` | `appendOpen(table_name, types=None)` | Begin append protocol with column type codes. When omitted, metadata can be loaded from server-side schema. | `1` or `0` |
-| `machbase` | `appendData(table_name, aTypes=None, values=None, format='YYYY-MM-DD HH24:MI:SS', on_ack=None)` | Append rows using the active append session. `aTypes` can be omitted and rows can be passed directly as the second argument. | `1` or `0` |
-| `machbase` | `appendDataByTime(table_name, aTypes=None, values=None, format='YYYY-MM-DD HH24:MI:SS', times=None, on_ack=None)` | Append rows with explicit epoch timestamps. `aTypes` can also be omitted and rows can be passed directly as the second argument. | `1` or `0` |
-| `machbase` | `appendFlush()` | Flush buffered append rows to disk. | `1` or `0` |
+| `machbase` | `appendData(table_name, aTypes=None, values=None, format='YYYY-MM-DD HH24:MI:SS', on_ack=None)` | Append rows using the active append session. Since 2.1, `aTypes` can be omitted and rows can be passed directly as the second argument. The data packet is sent immediately when called. | `1` or `0` |
+| `machbase` | `appendDataByTime(table_name, aTypes=None, values=None, format='YYYY-MM-DD HH24:MI:SS', times=None, on_ack=None)` | Append rows with explicit epoch timestamps. Since 2.1, `aTypes` can be omitted and rows can be passed directly as the second argument. The data packet is sent immediately when called. | `1` or `0` |
+| `machbase` | `appendFlush()` | Synchronization point that checks pending responses for already-sent append data. It is not a delayed-send buffer flush API. | `1` or `0` |
 | `machbase` | `appendClose()` | Close the append session. | `1` or `0` |
 | `machbase` | `append(table_name, aTypes=None, aValues=None, format='YYYY-MM-DD HH24:MI:SS')` | Convenience wrapper that opens, appends, and closes. `aTypes` can be omitted and `aValues` can be passed directly as second argument. | `1` or `0` |
 | `machbase` | `appendByTime(table_name, aTypes=None, aValues=None, format='YYYY-MM-DD HH24:MI:SS', times=None)` | Convenience wrapper for time-aware append. `aTypes` can be omitted and `aValues` can be passed directly as second argument. | `1` or `0` |
 
-## DB-API style API (2.1)
+## DB-API style API (2.3)
 
 | API | Description | Return |
 | -- | -- | -- |
@@ -164,11 +166,13 @@ Most `machbase` methods return `1` on success and `0` on failure. After each cal
 | `cursor.fetchall()` | Fetch all rows | `list` |
 | `cursor.close()` | Close cursor | `None` |
 | `cursor.rowcount` | Number of affected rows | `int` |
+| `connection.append(table, rows, types=None, times=None, strict=False)` | Append rows through the append protocol. Since 2.3, omitted trailing columns are padded as `NULL`. | Number of input rows |
 
-## 2.1 append without explicit column types (recommended)
+## 2.3 append without explicit column types and trailing NULL padding (recommended)
 
 `append()` and `appendByTime()` can be called without a type list.  
 Pass rows as the second argument and let the server metadata drive type handling.
+Since 2.3, rows may omit trailing columns, and omitted columns are stored as `NULL` through append null-bit metadata.
 
 ```python
 #!/usr/bin/env python3
@@ -202,9 +206,68 @@ if __name__ == '__main__':
     main()
 ```
 
+### DB-API append trailing NULL example
+
+`connect().append()` follows the same trailing `NULL` padding rule. Positional input cannot skip middle columns; pass `None` explicitly when a middle column should be stored as `NULL`.
+
+```python
+from machbaseAPI import connect
+
+conn = connect(host='127.0.0.1', port=5656, user='SYS', password='MANAGER')
+cur = conn.cursor()
+
+cur.execute('drop table py_append_null')
+cur.execute('create table py_append_null(ts datetime, name varchar(20), value double, note varchar(40))')
+
+conn.append('PY_APPEND_NULL', [
+    ['2024-01-01 10:00:00', 'sensor-1', 12.3],
+    ['2024-01-01 10:00:01', 'sensor-2', None, 'manual null'],
+])
+
+cur.execute('select ts, name, value, note from py_append_null order by ts')
+print(cur.fetchall())
+conn.close()
+```
+
+The first row omits `note`, so `note` is stored as `NULL`. The second row passes `None` at the `value` position, so `value` is stored as `NULL`.
+
+### TAG table append and metadata NULL example
+
+For TAG tables, values corresponding to `name`, `time`, and `value` are required. Additional columns and metadata columns after `value` can be omitted, and omitted columns are stored as `NULL`.
+
+```python
+from machbaseAPI import connect
+
+conn = connect(host='127.0.0.1', port=5656, user='SYS', password='MANAGER')
+cur = conn.cursor()
+
+cur.execute('drop table py_tag_append_null')
+cur.execute('''
+    create tag table py_tag_append_null (
+        name varchar(40) primary key,
+        time datetime basetime,
+        value double summarized,
+        status varchar(20)
+    ) metadata (
+        site varchar(20),
+        line integer
+    )
+''')
+
+conn.append('PY_TAG_APPEND_NULL', [
+    ['tag-1', '2024-01-01 10:00:00', 12.3],
+])
+
+cur.execute('select name, time, value, status, site, line from py_tag_append_null')
+print(cur.fetchall())
+conn.close()
+```
+
+In this example, `status`, `site`, and `line` are stored as `NULL`. A TAG append that omits `value` fails.
+
 ## API Reference and Samples (Legacy 1.x behavior)
 
-The examples below are mainly compatibility references from legacy releases. In the current 2.1 package, methods such as `getSessionId()`, `count()`, and `checkBit()` are not provided.
+The examples below are mainly compatibility references from legacy releases. In the current 2.3 package, methods such as `getSessionId()`, `count()`, and `checkBit()` are not provided.
 
 Update host, port, username, and password values as needed in each script. Every snippet is standalone and can be executed with `python3 script.py`.
 
@@ -421,7 +484,8 @@ if __name__ == '__main__':
 ### Append protocol primitives
 
 `appendOpen()`, `appendData()`, `appendFlush()`, and `appendClose()` stream rows efficiently.
-In 2.1 you can omit column types; server metadata is used automatically.
+Since 2.1, you can omit column types; server metadata is used automatically.
+`appendData()` and `appendDataByTime()` send data packets immediately when called. `appendFlush()` is a synchronization point that checks pending responses for already-sent append data.
 
 ```python
 #!/usr/bin/env python3
@@ -551,10 +615,10 @@ if __name__ == '__main__':
 
 #### machbase.checkBit()
 
-`checkBit()` was used for native pointer-size checks in legacy releases and is not available in the 2.1 pure-Python package.
+`checkBit()` was used for native pointer-size checks in legacy releases and is not available in the 2.3 pure-Python package.
 
 ### Low-level bindings
 
-The 2.1 package does not provide legacy ctypes helpers such as
+The 2.3 package does not provide legacy ctypes helpers such as
 `get_library_path()`, `openDB()`, `execAppend*()`, or pointer utility APIs.
 For low-level C-layer access, please keep using the pre-2.0 package.

--- a/content/dbms/sdk-integration/python.kr.md
+++ b/content/dbms/sdk-integration/python.kr.md
@@ -6,7 +6,7 @@ weight: 30
 
 ## 개요
 
-이 문서는 2.1 패키지를 기준으로 정리했습니다. PyPI 패키지명은 `machbaseapi`(소문자)이고 구현은 순수 Python입니다(네이티브 `.so/.dll/.dylib` 불필요).
+이 문서는 2.3 패키지를 기준으로 정리했습니다. PyPI 패키지명은 `machbaseapi`(소문자)이고 구현은 순수 Python입니다(네이티브 `.so/.dll/.dylib` 불필요).
 
 기존 `machbase` 사용 흐름은 유지됩니다.
 
@@ -15,6 +15,8 @@ weight: 30
 - DB-API 방식 `connect()`, `cursor()` 지원
 - `append*`는 `on_ack` 콜백을 추가할 수 있어 ACK 관찰 가능
 - `append()`, `appendByTime()`, `appendData()`, `appendDataByTime()`는 타입 리스트를 생략해도 동작합니다. 서버 메타데이터 기반으로 타입을 자동 추론합니다.
+- 2.3부터 append row의 마지막 일부 컬럼을 생략하면 append null-bit를 통해 `NULL`로 저장합니다.
+- TAG 테이블은 `value` 컬럼까지 필수이며, 이후 추가 컬럼과 metadata 컬럼은 생략 시 `NULL`로 저장할 수 있습니다.
 - 커넥션 풀 옵션(`pool_name`, `pool_size`, `pool_reset_session`) 미지원
 
 아래 예제는 기존 `machbase` 클래스 기반 레거시 스크립트를 대상으로 합니다.
@@ -25,7 +27,7 @@ weight: 30
 
 - `pip`을 사용할 수 있는 Python 3.8 이상
 - 접속 가능한 Machbase 서버와 계정 정보(기본 계정 `SYS/MANAGER`, 포트 `5656`)
-- 2.1은 네이티브 라이브러리 의존성이 없습니다.
+- 2.3은 네이티브 라이브러리 의존성이 없습니다.
 
 ### PyPI에서 설치
 
@@ -145,14 +147,14 @@ if __name__ == '__main__':
 | `machbase` | `selectClose()` | 열린 결과 집합 커서를 닫습니다. | `1` 또는 `0` |
 | `machbase` | `result()` | 최신 JSON 페이로드를 반환합니다. | JSON 문자열 |
 | `machbase` | `appendOpen(table_name, types=None)` | 컬럼 타입 코드를 지정하여 Append 프로토콜을 시작합니다. 생략 시 서버 메타데이터로 타입을 사용할 수 있습니다. | `1` 또는 `0` |
-| `machbase` | `appendData(table_name, aTypes=None, values=None, format='YYYY-MM-DD HH24:MI:SS', on_ack=None)` | 활성 Append 세션으로 행을 추가합니다. 2.1에서는 `aTypes`를 생략하고 두 번째 인자로 행을 바로 전달할 수 있습니다. | `1` 또는 `0` |
-| `machbase` | `appendDataByTime(table_name, aTypes=None, values=None, format='YYYY-MM-DD HH24:MI:SS', times=None, on_ack=None)` | 명시적 타임스탬프로 행을 추가합니다. 2.1에서는 `aTypes`를 생략하고 두 번째 인자로 행을 바로 전달할 수 있습니다. | `1` 또는 `0` |
-| `machbase` | `appendFlush()` | 버퍼링된 Append 데이터를 디스크에 플러시합니다. | `1` 또는 `0` |
+| `machbase` | `appendData(table_name, aTypes=None, values=None, format='YYYY-MM-DD HH24:MI:SS', on_ack=None)` | 활성 Append 세션으로 행을 추가합니다. 2.1 이후에는 `aTypes`를 생략하고 두 번째 인자로 행을 바로 전달할 수 있습니다. 호출 시 데이터 패킷을 즉시 전송합니다. | `1` 또는 `0` |
+| `machbase` | `appendDataByTime(table_name, aTypes=None, values=None, format='YYYY-MM-DD HH24:MI:SS', times=None, on_ack=None)` | 명시적 타임스탬프로 행을 추가합니다. 2.1 이후에는 `aTypes`를 생략하고 두 번째 인자로 행을 바로 전달할 수 있습니다. 호출 시 데이터 패킷을 즉시 전송합니다. | `1` 또는 `0` |
+| `machbase` | `appendFlush()` | 이미 전송된 Append 데이터의 pending response를 확인하는 동기화 지점입니다. 전송 지연 버퍼를 비우는 API가 아닙니다. | `1` 또는 `0` |
 | `machbase` | `appendClose()` | Append 세션을 종료합니다. | `1` 또는 `0` |
-| `machbase` | `append(table_name, aTypes=None, aValues=None, format='YYYY-MM-DD HH24:MI:SS')` | 열기·추가·닫기를 한 번에 처리하는 편의 함수입니다. 2.1에서는 `aTypes`를 생략하고 `aValues`를 두 번째 인자로 바로 전달할 수 있습니다. | `1` 또는 `0` |
-| `machbase` | `appendByTime(table_name, aTypes=None, aValues=None, format='YYYY-MM-DD HH24:MI:SS', times=None)` | 타임스탬프 인지 Append를 위한 편의 함수입니다. 2.1에서는 `aTypes`를 생략하고 `aValues`를 두 번째 인자로 바로 전달할 수 있습니다. | `1` 또는 `0` |
+| `machbase` | `append(table_name, aTypes=None, aValues=None, format='YYYY-MM-DD HH24:MI:SS')` | 열기·추가·닫기를 한 번에 처리하는 편의 함수입니다. 2.1 이후에는 `aTypes`를 생략하고 `aValues`를 두 번째 인자로 바로 전달할 수 있습니다. | `1` 또는 `0` |
+| `machbase` | `appendByTime(table_name, aTypes=None, aValues=None, format='YYYY-MM-DD HH24:MI:SS', times=None)` | 타임스탬프 인지 Append를 위한 편의 함수입니다. 2.1 이후에는 `aTypes`를 생략하고 `aValues`를 두 번째 인자로 바로 전달할 수 있습니다. | `1` 또는 `0` |
 
-## DB-API 스타일 API (2.1)
+## DB-API 스타일 API (2.3)
 
 | API | 설명 | 반환 |
 | -- | -- | -- |
@@ -164,11 +166,13 @@ if __name__ == '__main__':
 | `cursor.fetchall()` | 전체 조회 | `list` |
 | `cursor.close()` | 커서 종료 | `None` |
 | `cursor.rowcount` | 영향 행 수 | `int` |
+| `connection.append(table, rows, types=None, times=None, strict=False)` | Append 프로토콜로 row를 추가합니다. 2.3부터 trailing 컬럼 생략 시 `NULL` padding을 적용합니다. | 입력 row 수 |
 
-## 2.1 타입 리스트 생략 append (권장)
+## 2.3 append 타입 생략과 trailing NULL padding (권장)
 
-`append()`와 `appendByTime()`는 타입 리스트를 생략하고 호출할 수 있습니다.  
+`append()`와 `appendByTime()`는 타입 리스트를 생략하고 호출할 수 있습니다.
 두 번째 인자로 행 집합을 그대로 전달하면 서버 메타데이터 기반으로 처리합니다.
+2.3부터는 입력 row의 마지막 일부 컬럼을 생략할 수 있고, 생략된 컬럼은 append null-bit를 통해 `NULL`로 저장됩니다.
 
 ```python
 #!/usr/bin/env python3
@@ -202,9 +206,68 @@ if __name__ == '__main__':
     main()
 ```
 
+### DB-API append trailing NULL 예제
+
+`connect().append()`도 같은 trailing `NULL` padding 규칙을 사용합니다. 중간 컬럼을 건너뛰는 positional 입력은 지원하지 않으므로, 중간 값을 `NULL`로 입력하려면 해당 위치에 `None`을 명시합니다.
+
+```python
+from machbaseAPI import connect
+
+conn = connect(host='127.0.0.1', port=5656, user='SYS', password='MANAGER')
+cur = conn.cursor()
+
+cur.execute('drop table py_append_null')
+cur.execute('create table py_append_null(ts datetime, name varchar(20), value double, note varchar(40))')
+
+conn.append('PY_APPEND_NULL', [
+    ['2024-01-01 10:00:00', 'sensor-1', 12.3],
+    ['2024-01-01 10:00:01', 'sensor-2', None, 'manual null'],
+])
+
+cur.execute('select ts, name, value, note from py_append_null order by ts')
+print(cur.fetchall())
+conn.close()
+```
+
+첫 번째 row는 `note` 컬럼을 생략했으므로 `NULL`로 저장됩니다. 두 번째 row는 `value` 위치에 `None`을 명시했으므로 `value`가 `NULL`로 저장됩니다.
+
+### TAG 테이블 append와 metadata NULL 예제
+
+TAG 테이블은 `name`, `time`, `value`에 해당하는 값까지는 반드시 입력해야 합니다. `value` 뒤에 정의한 추가 컬럼 또는 metadata 컬럼은 생략할 수 있으며, 생략된 컬럼은 `NULL`로 저장됩니다.
+
+```python
+from machbaseAPI import connect
+
+conn = connect(host='127.0.0.1', port=5656, user='SYS', password='MANAGER')
+cur = conn.cursor()
+
+cur.execute('drop table py_tag_append_null')
+cur.execute('''
+    create tag table py_tag_append_null (
+        name varchar(40) primary key,
+        time datetime basetime,
+        value double summarized,
+        status varchar(20)
+    ) metadata (
+        site varchar(20),
+        line integer
+    )
+''')
+
+conn.append('PY_TAG_APPEND_NULL', [
+    ['tag-1', '2024-01-01 10:00:00', 12.3],
+])
+
+cur.execute('select name, time, value, status, site, line from py_tag_append_null')
+print(cur.fetchall())
+conn.close()
+```
+
+위 예제에서 `status`, `site`, `line`은 모두 `NULL`로 저장됩니다. 반대로 `value`를 생략한 TAG append는 오류로 처리됩니다.
+
 ## API 참고 및 샘플 (레거시 1.x 기준)
 
-아래 예제는 기존 레거시 버전 기준 정리입니다. 2.1 순수 Python에서는 `getSessionId()`, `count()`, `checkBit()`와 같은 API가 제공되지 않습니다. 필요 시 2.1 DB-API 예제를 참고하세요.
+아래 예제는 기존 레거시 버전 기준 정리입니다. 2.3 순수 Python에서는 `getSessionId()`, `count()`, `checkBit()`와 같은 API가 제공되지 않습니다. 필요 시 2.3 DB-API 예제를 참고하세요.
 
 각 스크립트에서 호스트·포트·계정 정보를 환경에 맞게 수정하세요. 모든 예제는 독립 실행이 가능하며 `python3 script.py` 형태로 실행할 수 있습니다.
 
@@ -420,7 +483,8 @@ if __name__ == '__main__':
 
 ### Append 프로토콜 기본기
 
-`appendOpen()`, `appendData()`, `appendFlush()`, `appendClose()`를 조합하면 행을 효율적으로 스트리밍할 수 있습니다. 2.1부터는 타입을 생략하고 `appendOpen()`으로 시작할 수 있습니다.
+`appendOpen()`, `appendData()`, `appendFlush()`, `appendClose()`를 조합하면 행을 효율적으로 스트리밍할 수 있습니다. 2.1 이후에는 타입을 생략하고 `appendOpen()`으로 시작할 수 있습니다.
+`appendData()`와 `appendDataByTime()`는 호출 시 데이터 패킷을 즉시 전송합니다. `appendFlush()`는 이미 전송된 append 데이터의 pending response를 확인하는 동기화 지점입니다.
 
 ```python
 #!/usr/bin/env python3
@@ -550,9 +614,9 @@ if __name__ == '__main__':
 
 #### machbase.checkBit()
 
-`checkBit()`는 기존 native 기반 버전에 있던 포인터 폭 확인용 API로, 2.1 순수 Python 패키지에서는 더 이상 제공되지 않습니다.
+`checkBit()`는 기존 native 기반 버전에 있던 포인터 폭 확인용 API로, 2.3 순수 Python 패키지에서는 더 이상 제공되지 않습니다.
 
 ### 저수준 바인딩
 
-2.1 순수 Python 패키지에서는 `get_library_path()`, `openDB()`, `execAppend*()` 또는 포인터 유틸리티 API(예: `getlAddr`, `getrAddr`)와 같은 저수준 `ctypes` 인터페이스를 제공하지 않습니다.
+2.3 순수 Python 패키지에서는 `get_library_path()`, `openDB()`, `execAppend*()` 또는 포인터 유틸리티 API(예: `getlAddr`, `getrAddr`)와 같은 저수준 `ctypes` 인터페이스를 제공하지 않습니다.
 기존 C 레이어 직접 접근이 필요한 경우에는 2.0 이전 버전(네이티브 기반 패키지)을 사용하세요.


### PR DESCRIPTION
## 요약

- Python SDK 매뉴얼 기준 버전을 `2.3`으로 갱신했습니다.
- `connect().append()`와 legacy `machbase` append 계열의 trailing `NULL` padding 규칙을 문서화했습니다.
- TAG 테이블에서 `value` 컬럼까지는 필수이고, 이후 추가 컬럼/metadata 컬럼은 생략 시 `NULL`로 저장되는 규칙을 추가했습니다.
- `appendData()` / `appendDataByTime()`는 호출 시 즉시 전송하고, `appendFlush()`는 이미 전송된 append 데이터의 pending response 확인 지점이라는 설명으로 수정했습니다.

## 변경 위치

- `content/dbms/sdk-integration/python.kr.md`
- `content/dbms/sdk-integration/python.en.md`

## 검증

- `hugo --printUnusedTemplates --printI18nWarnings`

기존 사이트 전역 i18n/template warning은 출력되지만 빌드는 성공했습니다.

## 관련

- Closes #129
- 구현 PR: https://github.com/machbase/dbms-nfx/pull/3672
